### PR TITLE
gitserver: Make janitor a standalone process

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -85,10 +85,11 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		logger,
 		db,
 		wrexec.NewNoOpRecordingCommandFactory(),
+		JanitorConfig{
+			ShardID:  "test-gitserver",
+			ReposDir: root,
+		},
 		&fakeDiskSizer{},
-		10,
-		"test-gitserver",
-		root,
 		func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 			// Don't actually attempt clones.
 			return "", nil
@@ -158,10 +159,11 @@ func TestCleanupInactive(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		wrexec.NewNoOpRecordingCommandFactory(),
+		JanitorConfig{
+			ShardID:  "test-gitserver",
+			ReposDir: root,
+		},
 		&fakeDiskSizer{},
-		10,
-		"test-gitserver",
-		root,
 		func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 			return "", nil
 		},
@@ -198,10 +200,11 @@ func TestCleanupWrongShard(t *testing.T) {
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			wrexec.NewNoOpRecordingCommandFactory(),
+			JanitorConfig{
+				ShardID:  "does-not-exist",
+				ReposDir: root,
+			},
 			&fakeDiskSizer{},
-			10,
-			"does-not-exist",
-			root,
 			func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 				return "", nil
 			},
@@ -236,10 +239,11 @@ func TestCleanupWrongShard(t *testing.T) {
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			wrexec.NewNoOpRecordingCommandFactory(),
+			JanitorConfig{
+				ShardID:  "gitserver-0",
+				ReposDir: root,
+			},
 			&fakeDiskSizer{},
-			10,
-			"gitserver-0",
-			root,
 			func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 				return "", nil
 			},
@@ -269,17 +273,17 @@ func TestCleanupWrongShard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wrongShardReposDeleteLimit = -1
-
 		cleanupRepos(
 			context.Background(),
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			wrexec.NewNoOpRecordingCommandFactory(),
+			JanitorConfig{
+				ShardID:                    "test-gitserver",
+				ReposDir:                   root,
+				WrongShardReposDeleteLimit: -1,
+			},
 			&fakeDiskSizer{},
-			10,
-			"gitserver-0",
-			root,
 			func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 				t.Fatal("clone called")
 				return "", nil
@@ -350,10 +354,11 @@ func TestGitGCAuto(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		wrexec.NewNoOpRecordingCommandFactory(),
+		JanitorConfig{
+			ShardID:  "test-gitserver",
+			ReposDir: root,
+		},
 		&fakeDiskSizer{},
-		10,
-		"test-gitserver",
-		root,
 		func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 			return "", nil
 		},
@@ -485,10 +490,11 @@ func TestCleanupExpired(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		wrexec.NewNoOpRecordingCommandFactory(),
+		JanitorConfig{
+			ShardID:  "test-gitserver",
+			ReposDir: root,
+		},
 		&fakeDiskSizer{},
-		10,
-		"test-gitserver",
-		root,
 		s.CloneRepo,
 		gitserver.GitserverAddresses{Addresses: []string{"test-gitserver"}},
 	)
@@ -573,10 +579,11 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 			logtest.Scoped(t),
 			mockDB,
 			wrexec.NewNoOpRecordingCommandFactory(),
+			JanitorConfig{
+				ShardID:  "test-gitserver",
+				ReposDir: root,
+			},
 			&fakeDiskSizer{},
-			10,
-			"test-gitserver",
-			root,
 			func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 				return "", nil
 			},
@@ -593,8 +600,6 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 	})
 
 	t.Run("Should delete the repo dir that is not defined in DB", func(t *testing.T) {
-		mockRemoveNonExistingReposConfig(true)
-		defer mockRemoveNonExistingReposConfig(false)
 		root := t.TempDir()
 		repoExists, repoNotExists := initRepos(root)
 
@@ -603,10 +608,12 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 			logtest.Scoped(t),
 			mockDB,
 			wrexec.NewNoOpRecordingCommandFactory(),
+			JanitorConfig{
+				ShardID:                "test-gitserver",
+				ReposDir:               root,
+				RemoveNonExistingRepos: true,
+			},
 			&fakeDiskSizer{},
-			10,
-			"test-gitserver",
-			root,
 			func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 				return "", nil
 			},
@@ -756,10 +763,11 @@ func TestCleanupOldLocks(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		wrexec.NewNoOpRecordingCommandFactory(),
+		JanitorConfig{
+			ShardID:  "test-gitserver",
+			ReposDir: root,
+		},
 		&fakeDiskSizer{},
-		10,
-		"test-gitserver",
-		root,
 		func(ctx context.Context, repo api.RepoName, opts CloneOptions) (cloneProgress string, err error) {
 			return "", nil
 		},
@@ -1434,7 +1442,7 @@ func TestNeedsMaintenance(t *testing.T) {
 	dir := t.TempDir()
 	gitDir := prepareEmptyGitRepo(t, dir)
 
-	needed, reason, err := needsMaintenance(gitDir)
+	needed, reason, err := needsMaintenance(gitDir, 10, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1458,7 +1466,7 @@ git commit-graph write --reachable --changed-paths
 		t.Fatalf("out=%s, err=%s", out, err)
 	}
 
-	needed, reason, err = needsMaintenance(gitDir)
+	needed, reason, err = needsMaintenance(gitDir, 10, 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/shared/config_test.go
+++ b/cmd/gitserver/shared/config_test.go
@@ -43,6 +43,30 @@ func TestConfigDefaults(t *testing.T) {
 	if have, want := config.JanitorInterval, time.Minute; have != want {
 		t.Errorf("invalid value for JanitorInterval: have=%s want=%s", have, want)
 	}
+	if have, want := config.EnableGitGCAuto, true; have != want {
+		t.Errorf("invalid value for EnableGitGCAuto: have=%t want=%t", have, want)
+	}
+	if have, want := config.EnableSGMaintenance, false; have != want {
+		t.Errorf("invalid value for EnableSGMaintenance: have=%t want=%t", have, want)
+	}
+	if have, want := config.GitAutoPackLimit, 50; have != want {
+		t.Errorf("invalid value for GitAutoPackLimit: have=%d want=%d", have, want)
+	}
+	if have, want := config.GitLooseObjectsLimit, 1024; have != want {
+		t.Errorf("invalid value for GitLooseObjectsLimit: have=%d want=%d", have, want)
+	}
+	if have, want := config.SGMLogExpiry, 24*time.Hour; have != want {
+		t.Errorf("invalid value for SGMLogExpiry: have=%v want=%v", have, want)
+	}
+	if have, want := config.SGMRetries, 3; have != want {
+		t.Errorf("invalid value for SGMRetries: have=%d want=%d", have, want)
+	}
+	if have, want := config.JanitorWrongShardReposDeleteLimit, 10; have != want {
+		t.Errorf("invalid value for JanitorWrongShardReposDeleteLimit: have=%d want=%d", have, want)
+	}
+	if have, want := config.JanitorRemoveNonExistingRepos, false; have != want {
+		t.Errorf("invalid value for JanitorRemoveNonExistingRepos: have=%t want=%t", have, want)
+	}
 }
 
 func TestConfig_PercentFree(t *testing.T) {

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -206,16 +206,24 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 			routines,
 			server.NewJanitor(
 				ctx,
-				server.JanitorConfig{
-					ShardID:            gitserver.Hostname,
-					JanitorInterval:    config.JanitorInterval,
-					ReposDir:           config.ReposDir,
-					DesiredPercentFree: config.JanitorReposDesiredPercentFree,
-				},
+				logger,
 				db,
 				recordingCommandFactory,
+				config.JanitorInterval,
+				server.JanitorConfig{
+					ShardID:                    gitserver.Hostname,
+					ReposDir:                   config.ReposDir,
+					DesiredPercentFree:         config.JanitorReposDesiredPercentFree,
+					EnableGitGCAuto:            config.EnableGitGCAuto,
+					EnableSGMaintenance:        config.EnableSGMaintenance,
+					GitAutoPackLimit:           config.GitAutoPackLimit,
+					GitLooseObjectsLimit:       config.GitLooseObjectsLimit,
+					SGMLogExpiry:               config.SGMLogExpiry,
+					SGMRetries:                 config.SGMRetries,
+					WrongShardReposDeleteLimit: config.JanitorWrongShardReposDeleteLimit,
+					RemoveNonExistingRepos:     config.JanitorRemoveNonExistingRepos,
+				},
 				gitserver.CloneRepo,
-				logger,
 			),
 		)
 	}


### PR DESCRIPTION
This makes the janitor independent of the server, so the two can be started independently, and most importantly, there's a clear boundary in code between the two.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
