### PR TITLE
docs: add section on where to manage package repo filters

### DIFF
--- a/doc/admin/external_service/package-repos.md
+++ b/doc/admin/external_service/package-repos.md
@@ -50,4 +50,6 @@ Filters can also have one of two behaviours:
 
 Having no configured _allow_ filters implicitly allows everything. _Block_ filters have priority over _allow_ filters (a blocked package or version will not be synced even if it is explicitly allowed).
 
+Filters can be created/managed in the `/site-admin/packages` page by clicking on "Manage package filters", or individual filters can be added based on existing package repositories by clicking on the meatball menu next to a package repository entry on same page.
+
 Package repository filter updates may require a few minutes to propagate through the system. The blocked status of a package repository will be updated in the UI and the relevant external service may add or remove repositories after syncing (visible in the site-admin page for the external service).


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
