### PR TITLE
K/guardrails filter

### DIFF
--- a/enterprise/cmd/frontend/internal/guardrails/filter/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/guardrails/filter/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "filter",
+    srcs = ["filter.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/filter",
+    visibility = ["//enterprise/cmd/frontend:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/frontend/internal/guardrails/attribution",
+        "//internal/conf/conftypes",
+    ],
+)

--- a/enterprise/cmd/frontend/internal/guardrails/filter/filter.go
+++ b/enterprise/cmd/frontend/internal/guardrails/filter/filter.go
@@ -1,0 +1,38 @@
+package filter
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/attribution"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// ServiceOpts configures Service.
+type ServiceOpts struct {
+	// Attribution is used to search for matches.
+	Attribution *attribution.Service
+
+	// Config is used to query how filtering is configured on the instance.
+	Config conftypes.SiteConfigQuerier
+}
+
+// Service is for the filter service which searches for any matches on
+// snippets of code.
+//
+// Use NewService to construct this value.
+type Service struct {
+	ServiceOpts
+}
+
+type FilterConfiguration struct {
+}
+
+// NewService returns a service configured with observationCtx.
+//
+// Note: this registers metrics so should only be called once with the same
+// observationCtx.
+func NewService(observationCtx *observation.Context, opts ServiceOpts) *Service {
+	return &Service{
+		operations:  newOperations(observationCtx),
+		ServiceOpts: opts,
+	}
+}

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -18,7 +18,7 @@ import (
 
 type client struct {
 	store       *store
-	passthrough ConfigurationSource
+	passthrough configurationSource
 	watchersMu  sync.Mutex
 	watchers    []chan struct{}
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -130,7 +130,7 @@ func initDefaultClient() *client {
 // the number of reads against the underlying configuration source (e.g. a
 // Postgres DB).
 type cachedConfigurationSource struct {
-	source ConfigurationSource
+	source configurationSource
 
 	ttl       time.Duration
 	entryMu   sync.Mutex
@@ -166,7 +166,7 @@ func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.R
 // InitConfigurationServerFrontendOnly creates and returns a configuration
 // server. This should only be invoked by the frontend, or else a panic will
 // occur. This function should only ever be called once.
-func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
+func InitConfigurationServerFrontendOnly(source configurationSource) *Server {
 	mode := getMode()
 
 	if mode == modeEmpty {
@@ -177,7 +177,7 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 		panic("cannot call this function while in client mode")
 	}
 
-	server := NewServer(&cachedConfigurationSource{
+	server := newServer(&cachedConfigurationSource{
 		source: source,
 		// conf.Watch poll rate is 5s, so we use half that.
 		ttl: 2500 * time.Millisecond,
@@ -211,7 +211,7 @@ var siteConfigEscapeHatchPath = env.Get("SITE_CONFIG_ESCAPE_HATCH_PATH", "$HOME/
 // an escape hatch such that if a site admin configures their instance in a way that they
 // cannot access the UI (for example by configuring auth in a way that locks them out)
 // they can simply edit this file in any of the frontend containers to undo the change.
-func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
+func startSiteConfigEscapeHatchWorker(c configurationSource) {
 	if os.Getenv("NO_SITE_CONFIG_ESCAPE_HATCH") == "1" {
 		return
 	}

--- a/internal/conf/mocks_test.go
+++ b/internal/conf/mocks_test.go
@@ -64,7 +64,7 @@ func NewStrictMockConfigurationSource() *MockConfigurationSource {
 // NewMockConfigurationSourceFrom creates a new mock of the
 // MockConfigurationSource interface. All methods delegate to the given
 // implementation, unless overwritten.
-func NewMockConfigurationSourceFrom(i ConfigurationSource) *MockConfigurationSource {
+func NewMockConfigurationSourceFrom(i configurationSource) *MockConfigurationSource {
 	return &MockConfigurationSource{
 		ReadFunc: &ConfigurationSourceReadFunc{
 			defaultHook: i.Read,

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -7,9 +7,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
-// ConfigurationSource provides direct access to read and write to the
+// configurationSource provides direct access to read and write to the
 // "raw" configuration.
-type ConfigurationSource interface {
+type configurationSource interface {
 	// Write updates the configuration. The Deployment field is ignored.
 	Write(ctx context.Context, data conftypes.RawUnified, lastID int32, authorUserID int32) error
 	Read(ctx context.Context) (conftypes.RawUnified, error)
@@ -17,7 +17,7 @@ type ConfigurationSource interface {
 
 // Server provides access and manages modifications to the site configuration.
 type Server struct {
-	source ConfigurationSource
+	source configurationSource
 	// sourceWrites signals when our app writes to the configuration source. The
 	// received channel should be closed when server.Raw() would return the new
 	// configuration that has been written to disk.
@@ -29,11 +29,11 @@ type Server struct {
 	startOnce sync.Once
 }
 
-// NewServer returns a new Server instance that mangages the site config file
+// newServer returns a new Server instance that mangages the site config file
 // that is stored at configSource.
 //
 // The server must be started with Start() before it can handle requests.
-func NewServer(source ConfigurationSource) *Server {
+func newServer(source configurationSource) *Server {
 	return &Server{
 		source:       source,
 		sourceWrites: make(chan chan struct{}, 1),


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
