### PR TITLE
Trigger a CI failure

### DIFF
--- a/dev/build-tracker/server_test.go
+++ b/dev/build-tracker/server_test.go
@@ -23,6 +23,8 @@ func TestGetBuild(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"buildNumber": "1234"})
 
 	t.Run("401 Unauthorized when in production mode and incorrect credentials", func(t *testing.T) {
+		t.Fail()
+
 		server := NewServer(logger, config.Config{Production: true, DebugPassword: "this is a test"})
 		rec := httptest.NewRecorder()
 		server.handleGetBuild(rec, req)


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
